### PR TITLE
Typo in var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ That's it! But how does it work? Here's the (slimmed down) code for the react-st
     }
 
     module.exports.addStylesheet = function() {
-        var styleTag = document.createElement('style');
+        var style = document.createElement('style');
         style.type = 'text/css';
         style.appendChild(document.createTextNode(_styles));
         document.head.appendChild(style);


### PR DESCRIPTION
Noticed small typo in name of variable in README. 
`styleTag` -> `style` bug fig.

(And hi 👋 Nick! Are you still using this package day-to-day? I'm doing a little react and remembered your package for css handling.)